### PR TITLE
Added GitHub client to Open Source Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Plugins / IOS - Android  additions
 - [Lime](https://github.com/fablue/lime-flutter) - Lime social network by Sebastian Sellmair
 - [Flitch](https://github.com/matanlurey/flitch) - Twitch client for Flutter by [Matan Lurey](https://twitter.com/matanlurey).
 - [WikiFlutter](https://github.com/nanowang/wiki-flutter) - Wikipedia reader by [Nano WANG](https://github.com/nanowang)
+- [DartHub](https://github.com/SamThompson/dart_hub) - A GitHub client written in flutter by [Sam Thompson](https://github.com/SamThompson)
 
 ### Games
 


### PR DESCRIPTION
Spotted at [FlutterDev](https://www.reddit.com/r/FlutterDev/comments/6l2edn/darthub_a_quick_and_dirty_github_client_written/). As stated by the author of the repo:

>  If you'd like to build and run this project, you'll need to create a keys.dart file and define two string constants (CLIENT_ID and CLIENT_SECRET) inside it.