### PR TITLE
Add FlutterMates to Templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Single Codebase, Two Apps with Flutter and Firebase (Google I/O '17)
 
 ### Templates
 
--[Movie Details](https://github.com/FlutterRocks/movie-details-ui) - A nice movie details page by [Iiro Krankka](https://github.com/roughike)
+- [Movie Details](https://github.com/FlutterRocks/movie-details-ui) - A nice movie details page by [Iiro Krankka](https://github.com/roughike)
+- [FlutterMates](https://github.com/CodemateLtd/FlutterMates) - How to load profiles from the randomuser.me API and a nice profile details page by [Iiro Krankka](https://github.com/roughike)
 
 ### Navigation
 - [Fluro](https://github.com/goposse/fluro) - The brightest, hippest, coolest router for Flutter with Navigation, wildcard, query, transitions by [Posse](http://goposse.com)


### PR DESCRIPTION
Hi!

First of all, thanks for including my previous stuff here!

I had this internal talk at our company, and that included a sample app on how to create [this profile details page](https://www.uplabs.com/posts/profile-ui-exploration) by Masum Parvej.

I added the link to aforementioned sample app in this PR, and also fixed the list in the Templated section. :)