### PR TITLE
Added Android links for hamilton and Newvoice apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ Single Codebase, Two Apps with Flutter and Firebase (Google I/O '17)
 ## Bonus
 
 ### Published Apps
-- [Hamilton](https://itunes.apple.com/fr/app/hamilton-the-official-app/id1255231054?mt=8&ign-mpt=uo%3D4) - Introducing Hamilton — The Official App. Fans’ access to all things Hamilton: An American Musical.
-- [Newsvoice](https://itunes.apple.com/se/app/newsvoice/id1208421834?l=en&mt=8) - Newsvoice shows all the news and perspectives from high quality sources in one place.
+- Hamilton ([iOS](https://itunes.apple.com/fr/app/hamilton-the-official-app/id1255231054?mt=8&ign-mpt=uo%3D4) / [Android](https://play.google.com/store/apps/details?id=com.hamilton.app)) - Introducing Hamilton — The Official App. Fans’ access to all things Hamilton: An American Musical.
+- Newsvoice ([iOS](https://itunes.apple.com/se/app/newsvoice/id1208421834?l=en&mt=8) / [Android](https://play.google.com/store/apps/details?id=com.newsvoice.newsvoice)) - Newsvoice shows all the news and perspectives from high quality sources in one place.
 - [Bendometer](https://itunes.apple.com/us/app/bendometer/id772557902?mt=8) - "Harmonica tuner". Learn how to play bends on your harmonica.
 - [Ecuestre Digital](https://itunes.apple.com/mx/app/ecuestre-digital/id1183799348?mt=8) - Ecuestre Digital provides real-time results and video streaming of Equestrian Events.
 <!--- - [Scrumizer](https://play.google.com/store/apps/details?id=com.robbieone.scrumizer) - Scrum master and product owner certification trainer by [Robert Felker](https://www.linkedin.com/in/robert-felker/) --->


### PR DESCRIPTION
Links for Android app copied from those 2 articles specifically referring Flutter being used for those apps:

Hamilton: https://9to5google.com/2017/08/14/hamilton-app-android-flutter-fuchsia-os/
Newsvoice: https://steemit.com/news/@crypticwyrm/newsvoice-an-app-using-google-s-flutter-framework-that-lets-you-see-news-from-different-perspectives-to-combat-bias
