### PR TITLE
Change Flutter Rocks to iirokrankka.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Also 👍| ⭐| 👏 links to support their authors !
 - [Sergi & Replace](https://sergiandreplace.com/) - Basic to advanced articles and tutorials [Sergi Martínez](https://github.com/sergiandreplace).
 - [Flutter by Example](https://flutterbyexample.com/) - Tutorials based on Redux, Firebase, Custom Animations, and UI.
 - [Flutter Institute](https://flutter.institute/) - Very original content and tutorials by [Brian Armstrong](https://twitter.com/flutterinst).
-- [Flutter Rocks](https://flutter.rocks/) - Blog about the joys of Flutter by [Iiro Krankka](https://twitter.com/koorankka).
+- [iirokrankka.com](https://iirokrankka.com/) - Articles and tutorials about Flutter, Dart and anything related by [Iiro Krankka](https://twitter.com/koorankka).
 - [Norbert](https://medium.com/@norbertkozsir) - In depth articles, features and app creation by [Norbert515](https://github.com/Norbert515).
 - [Welcome to Flutter](https://didierboelens.com) - English and French blog dedicated to providing practical solutions to most asked questions about Flutter by Didier Boelens.
 


### PR DESCRIPTION
Flutter Rocks now does a HTTP 301 (Moved Permanently) redirect to iirokrankka.com.

**Note**: All Flutter Rocks links will still be backwards compatible till the end of time, but this is more of a branding change.

So basically, this pull request is not needed but I thought it might make sense to update anyway.