### PR TITLE
Replace circle_indicator by page_view_indicator (on source.md)

### DIFF
--- a/source.md
+++ b/source.md
@@ -166,7 +166,7 @@ Also 👍| ⭐| 👏 links to support their authors !
 ### Navigation
 
 - [Fluro](https://github.com/goposse/fluro) <!--stargazers:goposse/fluro--> - The brightest, hippest, coolest router for Flutter with Navigation, wildcard, query, transitions by [Posse](http://goposse.com)
-- [Circle Indicator](https://github.com/long1eu/circle_indicator) <!--stargazers:long1eu/circle_indicator--> - Circle indicator for the PageViewer by [Lung Razvan](https://github.com/long1eu)
+- [PageView Indicator](https://github.com/leocavalcante/page_view_indicator) <!--stargazers:leocavalcante/page_view_indicator--> - Build page indicators for the PageView by [Leo Cavalcante](https://github.com/leocavalcante)
 - [Quick Actions](https://github.com/flutter/plugins/tree/master/packages/quick_actions) - Interact with the application's home screen quick actions
 - [Swiper](https://github.com/jzoom/flutter_swiper) <!--stargazers:long1eu/circle_indicator--> - Horizontal, Vertical, Partial swipe with indicator by [Xueliang Ren](https://github.com/jzoom)
 


### PR DESCRIPTION
Sorry about the wrong previous PR.

Unfortunately `circle_indicator` is about a year without updates, I tried it and found my self on issues like https://github.com/long1eu/circle_indicator/issues/7 I tried to PR somes fixes & features, but I came up with another package with a proper way to know the current page (`circle_indicator` does offset calculation instead of using `onPageChanged`) and you can use any other Widget with any other animation, not only growing dots.