### PR TITLE
Added dependencies package

### DIFF
--- a/source.md
+++ b/source.md
@@ -333,7 +333,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Redux](https://github.com/brianegan/flutter_redux) <!--stargazers:brianegan/flutter_redux--> - Built to work with [redux.dart](https://github.com/johnpryan/redux.dart), utilities that allow you to easily consume a Redux Store to build Widgets
 - [Dartea](https://github.com/p69/dartea) <!--stargazers:p69/dartea--> - Model View Update inspired by TEA from ELM by [Shilyagov P](https://github.com/p69)
 - [Inject](https://github.com/google/inject.dart) <!--stargazers:google/inject.dart--> - Compile-time dependency injection for Dart and Flutter by Google
-- [Dependencies](https://github.com/marcguilera/dart_dependencies_flutter) <!--stargazers:marcguilera/dart_dependencies_flutter--> - A simple and modular dependency injection system for Flutter.
+- [Dependencies](https://github.com/marcguilera/dart_dependencies_flutter) <!--stargazers:marcguilera/dart_dependencies_flutter--> - A simple and modular dependency injection system for Flutter by [marcguilera](https://github.com/marcguilera)
 - [Flutter_flux](https://github.com/google/flutter_flux) <!--stargazers:google/flutter_flux--> - Implementation of the Flux framework by Google
 
 ### Data

--- a/source.md
+++ b/source.md
@@ -333,6 +333,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Redux](https://github.com/brianegan/flutter_redux) <!--stargazers:brianegan/flutter_redux--> - Built to work with [redux.dart](https://github.com/johnpryan/redux.dart), utilities that allow you to easily consume a Redux Store to build Widgets
 - [Dartea](https://github.com/p69/dartea) <!--stargazers:p69/dartea--> - Model View Update inspired by TEA from ELM by [Shilyagov P](https://github.com/p69)
 - [Inject](https://github.com/google/inject.dart) <!--stargazers:google/inject.dart--> - Compile-time dependency injection for Dart and Flutter by Google
+- [Dependencies](https://github.com/marcguilera/dart_dependencies_flutter) <!--stargazers:marcguilera/dart_dependencies_flutter--> - A simple and modular dependency injection system for Flutter.
 - [Flutter_flux](https://github.com/google/flutter_flux) <!--stargazers:google/flutter_flux--> - Implementation of the Flux framework by Google
 
 ### Data

--- a/source.md
+++ b/source.md
@@ -333,7 +333,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Redux](https://github.com/brianegan/flutter_redux) <!--stargazers:brianegan/flutter_redux--> - Built to work with [redux.dart](https://github.com/johnpryan/redux.dart), utilities that allow you to easily consume a Redux Store to build Widgets
 - [Dartea](https://github.com/p69/dartea) <!--stargazers:p69/dartea--> - Model View Update inspired by TEA from ELM by [Shilyagov P](https://github.com/p69)
 - [Inject](https://github.com/google/inject.dart) <!--stargazers:google/inject.dart--> - Compile-time dependency injection for Dart and Flutter by Google
-- [Dependencies](https://github.com/marcguilera/dart_dependencies_flutter) <!--stargazers:marcguilera/dart_dependencies_flutter--> - A simple and modular dependency injection system for Flutter by [marcguilera](https://github.com/marcguilera)
+- [Dependencies](https://github.com/marcguilera/dependencies_flutter.dart) <!--stargazers:marcguilera/dart_dependencies_flutter--> - A simple and modular dependency injection system for Flutter by [marcguilera](https://github.com/marcguilera)
 - [Flutter_flux](https://github.com/google/flutter_flux) <!--stargazers:google/flutter_flux--> - Implementation of the Flux framework by Google
 
 ### Data


### PR DESCRIPTION
The `google:inject` package hasn't been updated in a while. For this reason, I went ahead and made a (hopefully) simple dependency injection container which can be used to register singletons, lazy singletons and factories with optional names and parameters. 

I'm sharing here in hopes it will be useful for the Flutter community.