### PR TITLE
Add the "Flutter France" Slack

### DIFF
--- a/source.md
+++ b/source.md
@@ -445,12 +445,15 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Dev Discord](https://discord.gg/N7Yshp4) - Discord server to discuss and get help by [Pritykin](https://twitter.com/AndrewPritykin)
 - [Flutter Community](https://github.com/fluttercommunity) - Central place for community made packages
 - [OpenFlutter](https://github.com/OpenFlutter) - Make it easier 让Flutter更简单
-- [Telegram chat (ru-RU)](https://t.me/rudart) - russian speaking Dart & Flutter community
 
 ### 🇫🇷France
 
-- [Twitter](https://twitter.com/FlutterDev) - Toutes les news et annonce dans votre flux.
+- [Twitter](https://twitter.com/FlutterDev) - Toutes les news et annonces dans votre flux.
 - [Slack](https://slack.flutter-france.fr) - Slack dédié à la communauté française.
+
+### 🇷🇺
+
+- [Telegram](https://t.me/rudart) - Russian speaking Dart & Flutter community.
 
 ## Books
 

--- a/source.md
+++ b/source.md
@@ -446,6 +446,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Flutter Community](https://github.com/fluttercommunity) - Central place for community made packages
 - [OpenFlutter](https://github.com/OpenFlutter) - Make it easier 让Flutter更简单
 - [Telegram chat (ru-RU)](https://t.me/rudart) - russian speaking Dart & Flutter community
+- [Flutter France Slack](https://slack.flutter-france.fr) - A Slack to discuss about Dart and Flutter in French
 
 ## Books
 

--- a/source.md
+++ b/source.md
@@ -446,7 +446,11 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Flutter Community](https://github.com/fluttercommunity) - Central place for community made packages
 - [OpenFlutter](https://github.com/OpenFlutter) - Make it easier 让Flutter更简单
 - [Telegram chat (ru-RU)](https://t.me/rudart) - russian speaking Dart & Flutter community
-- [Flutter France Slack](https://slack.flutter-france.fr) - A Slack to discuss about Dart and Flutter in French
+
+### 🇫🇷France
+
+- [Twitter](https://twitter.com/FlutterDev) - Toutes les news et annonce dans votre flux.
+- [Slack](https://slack.flutter-france.fr) - Slack dédié à la communauté française.
 
 ## Books
 


### PR DESCRIPTION
Hello,
This simple PR to add a link to the French Slack.