### PR TITLE
Add Ozzie to the list of libraries used for testing

### DIFF
--- a/source.md
+++ b/source.md
@@ -385,6 +385,10 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 - [Cache Manager](https://github.com/renefloor/flutter_cache_manager) <!--stargazers:renefloor/flutter_cache_manager--> - Generic cache manager by [Rene Floor](https://github.com/renefloor)
 
+### Testing
+
+- [Ozzie](https://github.com/jorgecoca/ozzie.flutter) <!--stargazers:jorgecoca/ozzie.flutter--> - Ozzie will take an screenshot during integration tests whenever you need by [Jorge Coca](https://github.com/jorgecoca)
+
 ## Open Source Apps
 
 ### Premium


### PR DESCRIPTION
Adding Ozzie to the list of libraries:

https://github.com/jorgecoca/ozzie.flutter
