### PR TITLE
fledge, A CI/CD Tool for Flutter

### DIFF
--- a/source.md
+++ b/source.md
@@ -250,6 +250,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Test on Travis](https://medium.com/@yegorj/test-flutter-apps-on-travis-3fd5142ecd8c) <!--claps:@yegorj/test-flutter-apps-on-travis-3fd5142ecd8c--> - Widget testing framework by [Yegor Jbanov](https://twitter.com/yegorjbanov)
 - [Building Apks/Ipas on Travis](https://medium.com/@yegorj/building-flutter-apks-and-ipas-on-travis-98d84d8e9b4) <!--claps:@yegorj/building-flutter-apks-and-ipas-on-travis-98d84d8e9b4--> - Automated build for Android and IOS by [Yegor Jbanov](https://twitter.com/yegorjbanov)
 - [Automatic code signing for iOS without Mac](https://blog.codemagic.io/automatic-code-signing-for-ios-that-doesnt-require-a-mac/) by Helina Ariva
+- [A CI/CD Tool for Flutter](https://medium.com/@nocnoc/cicd-for-flutter-fdc07fe52abd)<!--claps:@nocnoc/cicd-for-flutter-fdc07fe52abd--> - `fledge`, a continuous integration and distribution tool by [Maurice McCabe](https://twitter.com/nocnoc)
 
 ### Styling
 


### PR DESCRIPTION
This article, which generated a lot of interest, describes a new CI/CD tool, called `fledge` that auto-tests and auto-delivers to both Google and Apple stores. It is based on experience gained in supporting builds and testing (including integration testing on emulators/simulators) on travis of repo at https://github.com/brianegan/flutter_architecture_samples. The tool can be found at https://github.com/mmcc007/fledge with links to sample app and a demo, on travis, of build and delivery via both store consoles. 


FYI: There is a companion tool called `screenshots`, that has a nice video demo, at https://github.com/mmcc007/screenshots. There is a related article at https://medium.com/@nocnoc/automated-screenshots-for-flutter-f78be70cd5fd. Should I submit that also?
