### PR TITLE
A dart plugin use on code generation for internationalization

### DIFF
--- a/source.md
+++ b/source.md
@@ -438,7 +438,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Redux Starter/Code Generator](https://github.com/hillelcoren/flutter-redux-starter) <!--stargazers:hillelcoren/flutter-redux-starter--> - Starter project and code generator with Redux support by [Hillel Coren](https://twitter.com/hillelcoren)
 - [FlutterIcon](http://fluttericon.com/) <!--stargazers:ilikerobots/polyicon--> - Icon set generator by [Mike Hoolehan](https://github.com/ilikerobots)
 - [IntelliJ Redux](https://plugins.jetbrains.com/plugin/11277-redux) - Navigate Redux app by [Hillel Coren](https://twitter.com/hillelcoren)
-- [gen_lang](https://github.com/KingWu/gen_lang) - Code generator for Internationalization by [King Wu](https://github.com/KingWu)
+- [genLang](https://github.com/KingWu/gen_lang) <!--stargazers:KingWu/gen_lang--> - Code generator for Internationalization by [King Wu](https://github.com/KingWu)
 
 ### Desktop
 

--- a/source.md
+++ b/source.md
@@ -438,6 +438,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Redux Starter/Code Generator](https://github.com/hillelcoren/flutter-redux-starter) <!--stargazers:hillelcoren/flutter-redux-starter--> - Starter project and code generator with Redux support by [Hillel Coren](https://twitter.com/hillelcoren)
 - [FlutterIcon](http://fluttericon.com/) <!--stargazers:ilikerobots/polyicon--> - Icon set generator by [Mike Hoolehan](https://github.com/ilikerobots)
 - [IntelliJ Redux](https://plugins.jetbrains.com/plugin/11277-redux) - Navigate Redux app by [Hillel Coren](https://twitter.com/hillelcoren)
+- [gen_lang](https://github.com/KingWu/gen_lang) - Code generator for Internationalization by [King Wu](https://github.com/KingWu)
 
 ### Desktop
 


### PR DESCRIPTION
A dart plugin uses on code generation for internationalization to generate darts required by [Intl](https://github.com/dart-lang/intl). This plugin provides another way for code generation which is 
more simple compared with [Intl_translation](https://github.com/dart-lang/intl_translation).