### PR TITLE
Add 'Storm Tracker' under 'Open source apps'

### DIFF
--- a/source.md
+++ b/source.md
@@ -505,6 +505,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Spacex-Go](https://github.com/jesusrp98/spacex-go) <!--stargazers:jesusrp98/spacex-go--> - Simple yet powerful, open-source SpaceX launch tracker. [jesusrp98](https://twitter.com/jesusrp98).
 - [Superhero Interaction](https://github.com/pinkeshdarji/SuperHeroInteraction) <!--stargazers:pinkeshdarji/SuperHeroInteraction--> - Cool Superhero interaction animation by [Pinkesh Darji](https://github.com/pinkeshdarji)
 - [Reply](https://github.com/flschweiger/reply) <!--stargazers:flschweiger/reply--> - 'Reply' Material Design case study by [Frederik Schweiger](https://github.com/flschweiger)
+- [Storm Tracker](https://github.com/sanjul/storm-tracker) - 'Storm Tracker' is an app for tracking 'personal storms', a potential cycle tracker by [Sanjul As](https://github.com/sanjul)
 
 ### Games
 


### PR DESCRIPTION
'Storm Tracker' is an app for tracking 'personal storms', a potential cycle tracker by Sanjul As

You've read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) right ?

So tell me more about your awesome contribution and add the badge to your repo after it's accepted :D

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```
