### PR TITLE
Add Square In-App Payments SDK

### DIFF
--- a/source.md
+++ b/source.md
@@ -316,6 +316,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Inapp Purchase](https://github.com/dooboolab/flutter_inapp_purchase) <!--stargazers:dooboolab/flutter_inapp_purchase--> - Features set of 'in app purchase' derived from [react-native-iap](https://github.com/dooboolab/react-native-iap) by [dooboolab](https://github.com/dooboolab)
 - [Admob Flutter](https://github.com/YoussefKababe/admob_flutter) - Admob plugin that shows banner ads using native platform views by [Youssef Kababe](https://github.com/YoussefKababe)
 - [Facebook Audience Network](https://github.com/dreamsoftin/facebook_audience_network) - Facebook Audience Network Ad plugin that shows banner, interstitial, in-stream video, rewarded video & natvie ads by [Dreamsoft Innovations](https://github.com/dreamsoftin).
+- [Square In-App Payments SDK](https://github.com/square/in-app-payments-flutter-plugin) <!--stargazers:square/in-app-payments-flutter-plugin--> - Take payments by embedding a card entry form in your app that produces nonces from customer-provided card information or digital wallets by [Square](https://github.com/orgs/square)
 
 ## Templates
 


### PR DESCRIPTION
Square In-App Payments is awesome because it's free to use the SDK, it has beautiful Flutter card animations, it was announced at the Flutter Live event made Google's top 5 highlights list, and it's backed by Square, a payment platform that has processed billions of transactions.

This [Boring Show episode](https://youtu.be/_necENw9CUs) shows how to add this plugin to Flutter's shopping cart demo app or this video is [a shorter tutorial](https://youtu.be/HFAyy_AH0No).

![iap-opti](https://user-images.githubusercontent.com/378214/60628581-edb98080-9da6-11e9-92db-49d413e05cd7.gif)
