### PR TITLE
Add Flutter Press Weekly to the 'Bonus' section

### DIFF
--- a/source.md
+++ b/source.md
@@ -544,6 +544,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 ## Bonus
 
 - [It's All Widgets!](https://itsallwidgets.com) - Open list of published apps by [Hillel Coren](https://twitter.com/hillelcoren), [Thomas Burkhart](https://twitter.com/ThomasBurkhartB), [Simon Lightfoot](https://twitter.com/devangelslondon) and [Scott Stoll](https://twitter.com/scottstoll2017)
+- [Flutter Press Weekly](https://www.xriblu.com/flutter-press-weekly) - Weekly newsletter of each week's best articles about Flutter development. Hand-picked every Sunday by [Paul Blundell](https://github.com/blundell) and [Xavi Rigau](https://github.com/xrigau).
 
 ### Fun
 


### PR DESCRIPTION
Adds the [Flutter Press Weekly site](https://www.xriblu.com/flutter-press-weekly) to the 'Bonus' section.

See the previously sent newsletters in the [archive page](https://us19.campaign-archive.com/home/?u=1800cb34cabc1dabd900bcc16&id=34c76c53a2)