### PR TITLE
Add Before After widget package

### DIFF
--- a/source.md
+++ b/source.md
@@ -142,6 +142,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Slide Container](https://pub.dev/packages/slide_container) Slide vertically and horizontally with a smooth dampened motion by [Quentin Le Guennec](https://github.com/quentinleguennec).
 - [Rubber Bottom Sheet](https://github.com/mcrovero/rubber) <!--stargazers:mcrovero/rubber--> - An elastic material bottom sheet by [Mattia Crovero](https://github.com/mcrovero).
 - [Direct Select](https://github.com/LanarsInc/direct-select-flutter) - Selection widget with an ethereal, full-screen modal popup by [Ivan Yatsouba](https://github.com/iyatsouba).
+- [Before After](https://github.com/xsahil03x/before_after) <!--stargazers:xsahil03x/before_after--> - A beautiful slider which makes it easier to display the difference between two images, by [Sahil Kumar](https://github.com/xsahil03x).
 
 #### Sticky Headers
 


### PR DESCRIPTION
A flutter package which makes it easier to display the difference between two images.

Pub : https://pub.dev/packages/before_after

<img src="https://user-images.githubusercontent.com/25670178/61338086-8e9f4580-a855-11e9-8b7e-72244b6a456e.gif" height="400" alt="Screenshot"/>