### PR TITLE
Adding 'Custom Shape Clippers' package to effects list

### DIFF
--- a/source.md
+++ b/source.md
@@ -159,6 +159,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Parallax](https://github.com/FlutterRocks/page-transformer) <!--stargazers:FlutterRocks/page-transformer--> - ViewPager by [Iiro Krankka](https://github.com/roughike)
 - [Shimmer](https://github.com/hnvn/flutter_shimmer) <!--stargazers:hnvn/flutter_shimmer--> - Shimmer effect while content is loading by [HungHD](https://github.com/hnvn)
 - [Wave](https://github.com/i-protoss/wave) <!--stargazers:i-protoss/wave--> - Displaying some waves with custom color, duration, floating and blur effects by [RockerFlower](https://github.com/RockerFlower)
+- [Custom Shape Clippers](https://github.com/lohanidamodar/flutter_custom_clippers) <!--stargazers:lohanidamodar/flutter_custom_clippers--> - Clipping widgets to various custom shapes by [DamodarLohani](https://github.com/lohanidamodar)
 
 #### Calendar
 


### PR DESCRIPTION
Package custom shape clippers provides large number of custom clippers, that people can use to clip any widgets to lots of custom shapes in their app.
![arrow](https://user-images.githubusercontent.com/6360216/61844440-2557ac00-aebf-11e9-856a-1e9426212151.png)
![messag](https://user-images.githubusercontent.com/6360216/61844441-2557ac00-aebf-11e9-8e53-313603073a3a.png)
![screenshot1](https://user-images.githubusercontent.com/6360216/61844442-2557ac00-aebf-11e9-93c4-159eab75fe62.png)
![screenshot4](https://user-images.githubusercontent.com/6360216/61844443-25f04280-aebf-11e9-87d5-19084dc34a8f.png)



