### PR TITLE
Adding 'Flutter UI Challenges' app to the demonstration section

### DIFF
--- a/source.md
+++ b/source.md
@@ -248,8 +248,8 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Google Sign-In](https://github.com/flutter/plugins/tree/master/packages/google_sign_in) - Google OAuth
 - [Firebase Auth](https://github.com/flutter/plugins/tree/master/packages/firebase_auth) - Firebase OAuth
 - [Facebook Login](https://github.com/roughike/flutter_facebook_login) <!--stargazers:roughike/flutter_facebook_login--> - Authenticate with native Android & iOS Facebook login SDKs by [Iiro Krankka](https://github.com/roughike)
+- [Apple Sign-In](https://github.com/tomgilder/flutter_apple_sign_in) <!--stargazers:tomgilder/flutter_apple_sign_in--> - Apple sign in by [Tom Gilder](https://github.com/tomgilder)
 - [OAuth](https://github.com/hitherejoe/FlutterOAuth) <!--stargazers:hitherejoe/FlutterOAuth--> - Buffer, Strava, Unsplash, Github OAuth by [Joe Birch](http://www.hitherejoe.com)
-- [Instagram](https://hackernoon.com/instagram-authentication-with-flutter-df6424d2d56c) - Instagram auth by [Wilfried Mbouenda Mbogne](http://developer-journey.com/)
 - [Firebase Phone Auth](https://medium.com/@gildaswise/flutter-adding-sign-in-with-google-and-phone-authentication-to-your-app-69f681518f9b) <!--claps:@gildaswise/flutter-adding-sign-in-with-google-and-phone-authentication-to-your-app-69f681518f9b--> - Phone number auth via SMS by [Gildásio Filho](https://github.com/gildaswise)
 - [SimpleAuth](https://github.com/Clancey/simple_auth) <!--stargazers:Clancey/simple_auth--> - Azure Active Directory, Amazon, Dropbox, Facebook, Github, Google, Instagram, Linked In, Microsoft Live Connect, Github, OAuth, Basic Auth by [James Clancey](https://github.com/Clancey)
 - [Flutter AppAuth](https://github.com/MaikuB/flutter_appauth) <!--stargazers:MaikuB/flutter_appauth--> - Plugin for displaying local notifications by [Michael Bui](https://github.com/MaikuB)

--- a/source.md
+++ b/source.md
@@ -122,6 +122,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Official Gallery](https://github.com/flutter/flutter/tree/master/examples/flutter_gallery) - Demo for the material design widgets provided by Flutter Team
 - [Flutter Examples](https://github.com/nisrulz/flutter-examples) <!--stargazers:nisrulz/flutter-examples--> - Simple basic isolated apps for devs by [Nishant Srivastava](https://github.com/nisrulz)
 - [Flutter Catalog](https://github.com/X-Wei/flutter_catalog) <!--stargazers:X-Wei/flutter_catalog--> - An app showcasing Flutter components, with side-by-side source code view, by [X-Wei](https://github.com/X-Wei)
+- [Flutter UI Challenges](https://github.com/lohanidamodar/flutter_ui_challenges) <!--stargazers:lohanidamodar/flutter_ui_challenges--> - An app showcasing real life UIs in coded in flutter, with source code right in the application, by [Damodar Lohani](https://github.com/lohanidamodar)
 
 ### UI
 


### PR DESCRIPTION
I have developed an open source application, consisting of real life app UIs, coded in flutter, along with source code that users can view right in the app to learn how the UIs are coded. I would like to add that app to the demonstration section.

Released in App Store(https://apps.apple.com/np/app/flutter-ui-challenges/id1473537882) and
in Play Store (https://play.google.com/store/apps/details?id=com.popupbits.flutteruichallenges)

![Screenshot_1564027183](https://user-images.githubusercontent.com/6360216/61844902-e0347980-aec0-11e9-846a-0f0436d2e441.png)
![cake](https://user-images.githubusercontent.com/6360216/61844858-b8451600-aec0-11e9-8c4c-651342ec569d.png)
![profile5](https://user-images.githubusercontent.com/6360216/61844860-bbd89d00-aec0-11e9-86b3-986a7c820553.png)
