### PR TITLE
Add Flutter PageView indicator like in Instagram

### DIFF
--- a/source.md
+++ b/source.md
@@ -252,6 +252,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 - [Fluro](https://github.com/goposse/fluro) <!--stargazers:goposse/fluro--> - The brightest, hippest, coolest router for Flutter with Navigation, wildcard, query, transitions by [Posse](http://goposse.com)
 - [PageView Indicator](https://github.com/leocavalcante/page_view_indicator) <!--stargazers:leocavalcante/page_view_indicator--> - Build page indicators for the PageView by [Leo Cavalcante](https://github.com/leocavalcante)
+- [FlutterScrollingPageIndicator](https://github.com/NikitaZhelonkin/FlutterScrollingPageIndicator) <!--stargazers:NikitaZhelonkin/FlutterScrollingPageIndicator--> - PageView indicator like in Instagram by [Nikita Zhelonkin](https://github.com/NikitaZhelonkin)
 - [Swiper](https://github.com/jzoom/flutter_swiper) <!--stargazers:long1eu/circle_indicator--> - Horizontal, Vertical, Partial swipe with indicator by [Xueliang Ren](https://github.com/jzoom)
 
 ### Auth


### PR DESCRIPTION
It's an awesome "scrolling" page view indicator like Instagram has. Supports horizontal/vertical orientation, custom color and size!

![preview](https://github.com/NikitaZhelonkin/FlutterScrollingPageIndicator/raw/master/demo.gif) 
