### PR TITLE
Add Navigator with no context to Flutter

### DIFF
--- a/source.md
+++ b/source.md
@@ -257,6 +257,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Fluro](https://github.com/goposse/fluro) <!--stargazers:goposse/fluro--> - The brightest, hippest, coolest router for Flutter with Navigation, wildcard, query, transitions by [Posse](http://goposse.com)
 - [PageView Indicator](https://github.com/leocavalcante/page_view_indicator) <!--stargazers:leocavalcante/page_view_indicator--> - Build page indicators for the PageView by [Leo Cavalcante](https://github.com/leocavalcante)
 - [Swiper](https://github.com/jzoom/flutter_swiper) <!--stargazers:long1eu/circle_indicator--> - Horizontal, Vertical, Partial swipe with indicator by [Xueliang Ren](https://github.com/jzoom)
+- [Get](https://github.com/jonataslaw/get) - Navigate with no context on Flutter mobile and get full support for friendly url routes in Flutter_web. by [Jonny Borges](https://github.com/jonataslaw).
 
 ### Auth
 


### PR DESCRIPTION
Get is a package than allow navigate on Flutter with no context to mobile Apps(very useful with BLoC, where business logic can determine which screen to display, but business logic has no context.), friendly urls to flutter_web and improve navigation performance with no rebuild of MaterialApp with each navigation (Navigator.push does this).

You've read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) right ? Yes

So tell me more about your awesome contribution and add the badge to your repo after it's accepted :D

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```
