### PR TITLE
Removing reference to [Fluttery] (the youtube channel under Videos header)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Mtechviral](https://www.youtube.com/watch?v=qWL1lGchpRA&list=PLR2qQy0Zxs_UdqAcaipPR3CG1Ly57UlhV) [182🎬] - [Hindi/English] Mtechviral Series By [Pawan Kumar](https://github.com/iampawan).
 - [Flutter in Practice](https://www.youtube.com/playlist?list=PLhXZp00uXBk5TSY6YOdmpzp1yG3QbFvrN) - Free video course for beginners & non-programmers by [Zaiste](https://zaiste.net/).
 - [Whatsupcoders](https://www.youtube.com/c/whatsupcoders) [83🎬] - Free video series on Flutter Widgets by [Kamal](https://github.com/whatsupcoders).
-- [Fluttery](https://www.youtube.com/channel/UCtWyVkPpb8An90SNDTNF0Pg) - High-production value and in-depth challenges.
 
 
 ## Components


### PR DESCRIPTION
  - Reference to Youtube channel does not exist
  - YouTube channel page reads "This channel does not exist"

You've read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) right ? 

So tell me more about your awesome contribution and add the badge to your repo after it's accepted :D

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```
