### PR TITLE
Change `amap_base_flutter` to `amap_map_fluttify`.

### DIFF
--- a/source.md
+++ b/source.md
@@ -240,7 +240,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [GeoCoder](https://github.com/aloisdeniel/flutter_geocoder) <!--stargazers:aloisdeniel/flutter_geocoder--> - Forward and reverse geocoding by [Aloïs Deniel](https://aloisdeniel.github.com)
 - [Map](https://github.com/apptreesoftware/flutter_map) <!--stargazers:apptreesoftware/flutter_map--> - Solution based on [Leaflet](http://leafletjs.com/) and customizable by [AppTree Software](https://github.com/apptreesoftware)
 - [Mapbox GL](https://github.com/mapbox/flutter-mapbox-gl) <!--stargazers:mapbox/flutter-mapbox-gl--> - Interactive, customizable vector maps by Mapbox
-- [AMap](https://github.com/OpenFlutter/amap_base_flutter) <!--stargazers:OpenFlutter/amap_base_flutter--> - Access to AMap services(高德地图) by [OpenFlutter](https://github.com/OpenFlutter)
+- [AMap](https://github.com/fluttify-project/amap_map_fluttify) <!--stargazers:fluttify-project/amap_map_fluttify--> - Access to AMap services(高德地图) by [fluttify-project](https://github.com/fluttify-project)
 
 ### Charts
 


### PR DESCRIPTION
I am the main author of `amap_base_flutter` plugin and deprecated this plugin last year, I recommend to use my new amap plugin `amap_map_fluttify` to embedding amap widget to their flutter app. This new amap plugin base on `Fluttify` engine, a dart bindings generator for native SDK.
