### PR TITLE
Add flutter intl plugin to VSCode and IntelliJ categories

### DIFF
--- a/source.md
+++ b/source.md
@@ -590,12 +590,12 @@ This section contains libraries that take an experimental or unorthodox approach
 
 - [Awesome Snippets](https://marketplace.visualstudio.com/items?itemName=Nash.awesome-flutter-snippets) - Collection of commonly used classes and methods by [Nash](https://twitter.com/Nash0x7E2)
 - [Flutter Files](https://marketplace.visualstudio.com/items?itemName=gornivv.vscode-flutter-files) - Quick generation for BLoC templates files by context menu by [Gorniv](https://github.com/gorniv).
-- [Flutter Intl](https://marketplace.visualstudio.com/items?itemName=localizely.flutter-intl) - Flutter i18n binding from .arb files by [Localizely](https://twitter.com/localizely)
+- [Flutter Intl](https://marketplace.visualstudio.com/items?itemName=localizely.flutter-intl) - i18n binding from arb files by [Localizely](https://twitter.com/localizely)
 
 ### IntelliJ / Android Studio
 
 - [Enhancement_Suite](https://github.com/marius-h/flutter_enhancement_suite) <!--stargazers:marius-h/flutter_enhancement_suite--> - Search for pub.dev libraries, update version, Bloc, Snippet, etc you're covered by [Marius Höfler](https://github.com/marius-h)
-- [Flutter Intl](https://plugins.jetbrains.com/plugin/13666-flutter-intl) - Flutter i18n binding from .arb files by [Localizely](https://twitter.com/localizely)
+- [Flutter Intl](https://plugins.jetbrains.com/plugin/13666-flutter-intl) - 18n binding from arb files by [Localizely](https://twitter.com/localizely)
 
 ### Desktop
 

--- a/source.md
+++ b/source.md
@@ -590,10 +590,12 @@ This section contains libraries that take an experimental or unorthodox approach
 
 - [Awesome Snippets](https://marketplace.visualstudio.com/items?itemName=Nash.awesome-flutter-snippets) - Collection of commonly used classes and methods by [Nash](https://twitter.com/Nash0x7E2)
 - [Flutter Files](https://marketplace.visualstudio.com/items?itemName=gornivv.vscode-flutter-files) - Quick generation for BLoC templates files by context menu by [Gorniv](https://github.com/gorniv).
+- [Flutter Intl](https://marketplace.visualstudio.com/items?itemName=localizely.flutter-intl) - Flutter i18n binding from .arb files by [Localizely](https://twitter.com/localizely)
 
 ### IntelliJ / Android Studio
 
 - [Enhancement_Suite](https://github.com/marius-h/flutter_enhancement_suite) <!--stargazers:marius-h/flutter_enhancement_suite--> - Search for pub.dev libraries, update version, Bloc, Snippet, etc you're covered by [Marius Höfler](https://github.com/marius-h)
+- [Flutter Intl](https://plugins.jetbrains.com/plugin/13666-flutter-intl) - Flutter i18n binding from .arb files by [Localizely](https://twitter.com/localizely)
 
 ### Desktop
 


### PR DESCRIPTION
Added IDE plugin for VS Code and IntelliJ / Android Studio that makes i18n easier for Flutter development.

Plugin for VS Code: https://marketplace.visualstudio.com/items?itemName=localizely.flutter-intl
Plugin for IntelliJ / Android Studio: https://plugins.jetbrains.com/plugin/13666-flutter-intl