### PR TITLE
Add NextBus SG to apps

### DIFF
--- a/source.md
+++ b/source.md
@@ -579,6 +579,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Chillify](https://github.com/KarimElghamry/chillify) - Fancy music app made with Provider and Bloc pattern by [Karim Elghamry](https://github.com/KarimElghamry)
 - [Pokedex](https://github.com/scitbiz/flutter_pokedex) - Pokedex app with beautiful UI and smooth animation by [Hung Pham](https://github.com/scitbiz)
 - [Timy Messenger](https://github.com/janoodleFTW/timy-messenger) <!--stargazers:janoodleFTW/timy-messenger--> - Group messaging app with a focus on organizing events by [Miguel Beltran](https://github.com/miquelbeltran) and [Franz Heinfling](https://github.com/fheinfling)
+- [NextBus SG](https://github.com/themindstorm/NextBusSG) <!--stargazers:themindstorm/NextBusSG--> - A public transport app for buses in Singapore by [themindstorm](https://github.com/themindstorm/)
 
 ## Utilities
 

--- a/source.md
+++ b/source.md
@@ -579,7 +579,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Chillify](https://github.com/KarimElghamry/chillify) - Fancy music app made with Provider and Bloc pattern by [Karim Elghamry](https://github.com/KarimElghamry)
 - [Pokedex](https://github.com/scitbiz/flutter_pokedex) - Pokedex app with beautiful UI and smooth animation by [Hung Pham](https://github.com/scitbiz)
 - [Timy Messenger](https://github.com/janoodleFTW/timy-messenger) <!--stargazers:janoodleFTW/timy-messenger--> - Group messaging app with a focus on organizing events by [Miguel Beltran](https://github.com/miquelbeltran) and [Franz Heinfling](https://github.com/fheinfling)
-- [NextBus SG](https://github.com/themindstorm/NextBusSG) <!--stargazers:themindstorm/NextBusSG--> - A public transport app for buses in Singapore by [themindstorm](https://github.com/themindstorm/)
+- [NextBus SG](https://github.com/themindstorm/NextBusSG) <!--stargazers:themindstorm/NextBusSG--> - A public transport app for Singapore by [themindstorm](https://github.com/themindstorm/)
 
 ## Utilities
 


### PR DESCRIPTION
**You've read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) right?** Yes

**So tell me more about your awesome contribution and add the badge to your repo after it's accepted :D**

[NextBus SG](https://github.com/themindstorm/NextBusSG) is a minimalistic bus timings and public transport app for Singapore. It shows users bus timings, bus routes, bus stop information, and a train map. I've included images of the app's UI in the [readme](https://github.com/themindstorm/NextBusSG).

While the app is specific to Singapore, but the data and APIs can be easily changed to apply it to different countries.