### PR TITLE
Added NextBus SG app

### DIFF
--- a/source.md
+++ b/source.md
@@ -579,6 +579,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Chillify](https://github.com/KarimElghamry/chillify) - Fancy music app made with Provider and Bloc pattern by [Karim Elghamry](https://github.com/KarimElghamry)
 - [Pokedex](https://github.com/scitbiz/flutter_pokedex) - Pokedex app with beautiful UI and smooth animation by [Hung Pham](https://github.com/scitbiz)
 - [Timy Messenger](https://github.com/janoodleFTW/timy-messenger) <!--stargazers:janoodleFTW/timy-messenger--> - Group messaging app with a focus on organizing events by [Miguel Beltran](https://github.com/miquelbeltran) and [Franz Heinfling](https://github.com/fheinfling)
+- [NextBus SG](https://github.com/ninest/NextBusSG/) <!--stargazers:ninest/NextBusSG--> - A bus timings and public transportation app for Singapore by [ninest](https://github.com/ninest)
 
 ## Utilities
 


### PR DESCRIPTION
**You've read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) right?** Yes

**So tell me more about your awesome contribution and add the badge to your repo after it's accepted :D**

[NextBus SG](https://github.com/ninest/NextBusSG/) is a bus timings and public transportation app for Singapore. It has many features such as showing bus crowd, bus routes, and the train map (in dark mode too!) Users are also able to rename bus stops if the actual bus stop name doesn't make much sense to them.

I've added screenshots to the [readme](https://github.com/ninest/NextBusSG/).

While the app is specific to Singapore, the data can easily be changed to that of another country.