### PR TITLE
Added a live stream "FlutterExplained" to the list of Live Streams

### DIFF
--- a/live.md
+++ b/live.md
@@ -24,7 +24,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 ## Live
 
-- [Streams](#steams)
+- [Streams](#streams)
 
 ## Streams
 
@@ -64,6 +64,9 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 ### 🇩🇪 Germany
 
+| Stream Information                                                                                          | Monday | Tuesday | Wednesday                                                                               | Thursday | Friday | Saturday                                                                            | Sunday |
+| ----------------------------------------------------------------------------------------------------------- | ------ | ------- | --------------------------------------------------------------------------------------- | -------- | ------ | ----------------------------------------------------------------------------------- | ------ |
+| [Channel: FlutterExplained](https://youtube/c/flutterexplained)<br/>Platform: Youtube<br/>Language: English |        |         | [Pair Programming - Flutter Explained](https://flutterexplained.live)<br/>3:00 p.m. CET |          |        | [Solo Programming / Just Chatting](https://flutterexplained.live)<br/>3:00 p.m. CET |        |
 
 ### 🇬🇷 Greece
 

--- a/live.md
+++ b/live.md
@@ -30,7 +30,6 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 
 
-
 ### 🇺🇸 United States
 
 | Monday          | Tuesday         | Wednesday       | Thursday        | Friday          | Saturday        | Sunday              


### PR DESCRIPTION
You've read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md), right? Yes, indeed.

We are working at the moment on two weekly live streams, that includes one pair programming session on Wednesday and a Solo programming session on a Saturday. We work there together at basic Flutter Applications and talk roundabout development and answer all questions of the chat.

We are fully dedicated to it and love our work with the community. It would be an honour to be a part of the Flutter Awesome package.

(Side Note: I fixed the anchor to "Streams")

The result would look like this:
![grafik](https://user-images.githubusercontent.com/8026644/83165297-98e4ce00-a10d-11ea-9419-b1c4f5898e86.png)

https://github.com/md-weber/awesome-flutter/blob/master/live.md

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
