### PR TITLE
Add Sentry to the Crash monitoring section

### DIFF
--- a/source.md
+++ b/source.md
@@ -464,7 +464,11 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 ### Log / Tracing
 
 - [Catcher](https://github.com/jhomlala/catcher) <!--stargazers:jhomlala/catcher--> - Automatically catches errors and handles them by [Jakub Homlala](https://github.com/jhomlala)
-- [Logger](https://github.com/leisim/logger) <!--stargazers:leisim/logger--> - Easy to use and beautiful logs by [Simon Leier](https://github.com/leisim)
+- [Logger](https://github.com/leisim/logger) <!--stargazers:flutter/sentry--> - Easy to use and beautiful logs by [Simon Leier](https://github.com/leisim)
+
+### Crash monitoring
+
+- [Sentry](https://sentry.io/) <!--stargazers:leisim/logger--> - Sentry provides self-hosted and cloud-based error monitoring that helps all software teams discover, triage, and prioritize errors in real-time by [Flutter](https://github.com/flutter/sentry)
 
 ## Frameworks
 

--- a/source.md
+++ b/source.md
@@ -464,11 +464,11 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 ### Log / Tracing
 
 - [Catcher](https://github.com/jhomlala/catcher) <!--stargazers:jhomlala/catcher--> - Automatically catches errors and handles them by [Jakub Homlala](https://github.com/jhomlala)
-- [Logger](https://github.com/leisim/logger) <!--stargazers:flutter/sentry--> - Easy to use and beautiful logs by [Simon Leier](https://github.com/leisim)
+- [Logger](https://github.com/leisim/logger) <!--stargazers:leisim/logger--> - Easy to use and beautiful logs by [Simon Leier](https://github.com/leisim)
 
 ### Crash monitoring
 
-- [Sentry](https://sentry.io/) <!--stargazers:leisim/logger--> - Sentry provides self-hosted and cloud-based error monitoring that helps all software teams discover, triage, and prioritize errors in real-time by [Flutter](https://github.com/flutter/sentry)
+- [Sentry](https://sentry.io/) <!--stargazers:flutter/sentry--> - Sentry provides self-hosted and cloud-based error monitoring that helps all software teams discover, triage, and prioritize errors in real-time by [Flutter](https://github.com/flutter/sentry)
 
 ## Frameworks
 


### PR DESCRIPTION
You've read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) right ? Yes

So tell me more about your awesome contribution and add the badge to your repo after it's accepted :D

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```

[Link to GH repo](https://github.com/flutter/sentry)
[Link to Sentry docs](https://docs.sentry.io/platforms/flutter/)
[Link to Flutter docs for crash monitoring](https://flutter.dev/docs/cookbook/maintenance/error-reporting)