### PR TITLE
Add AuthPass to apps

### DIFF
--- a/source.md
+++ b/source.md
@@ -593,6 +593,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Pokedex](https://github.com/scitbiz/flutter_pokedex) - Pokedex app with beautiful UI and smooth animation by [Hung Pham](https://github.com/scitbiz)
 - [Timy Messenger](https://github.com/janoodleFTW/timy-messenger) <!--stargazers:janoodleFTW/timy-messenger--> - Group messaging app with a focus on organizing events by [Miguel Beltran](https://github.com/miquelbeltran) and [Franz Heinfling](https://github.com/fheinfling)
 - [GitJournal](https://github.com/GitJournal/GitJournal) <!--stargazers:GitJournal/GitJournal--> - Journaling your data in a Git Repo by [Vishesh Handa](https://github.com/vHanda)
+- [AuthPass](https://github.com/authpass/authpass) <!--stargazers:authpass/authpass--> - Keepass compatible password manager for mobile and desktop by [hpoul](https://github.com/hpoul)
 
 ## Utilities
 


### PR DESCRIPTION
## Description

AuthPass is an open source password manager currently available for Android, iOS, MacOS and Linux (Windows still has some quirks). https://github.com/authpass/authpass

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
