### PR TITLE
Added Flutter News App to open source apps

### DIFF
--- a/source.md
+++ b/source.md
@@ -596,6 +596,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Timy Messenger](https://github.com/janoodleFTW/timy-messenger) <!--stargazers:janoodleFTW/timy-messenger--> - Group messaging app with a focus on organizing events by [Miguel Beltran](https://github.com/miquelbeltran) and [Franz Heinfling](https://github.com/fheinfling)
 - [GitJournal](https://github.com/GitJournal/GitJournal) <!--stargazers:GitJournal/GitJournal--> - Journaling your data in a Git Repo by [Vishesh Handa](https://github.com/vHanda)
 - [AuthPass](https://github.com/authpass/authpass) <!--stargazers:authpass/authpass--> - Keepass compatible password manager for mobile and desktop by [hpoul](https://github.com/hpoul)
+- [Flutter News App](https://github.com/CoderJava/Flutter-News-App) - Flutter News App with newsapi.org and developed using the Test Driven Development by [CoderJava](https://github.com/CoderJava)
 
 ## Utilities
 


### PR DESCRIPTION
## Description

Flutter News App  is News App with newsapi.org and developed using the Test Driven Development. Here is the link to the [repo](https://github.com/CoderJava/Flutter-News-App)

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
