### PR TITLE
Add RANEPA Timetable to open source apps

### DIFF
--- a/source.md
+++ b/source.md
@@ -596,6 +596,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [GitJournal](https://github.com/GitJournal/GitJournal) <!--stargazers:GitJournal/GitJournal--> - Journaling your data in a Git Repo by [Vishesh Handa](https://github.com/vHanda)
 - [AuthPass](https://github.com/authpass/authpass) <!--stargazers:authpass/authpass--> - Keepass compatible password manager for mobile and desktop by [hpoul](https://github.com/hpoul)
 - [Fwitter](https://github.com/TheAlphamerc/flutter_twitter_clone) <!--stargazers:TheAlphamerc/flutter_twitter_clone--> - Full Twitter clone using Firebase solution by [Sonu Sharma](https://github.com/TheAlphamerc)
+- [RANEPA Timetable](https://github.com/CoolONEOfficial/ranepa_timetable) <!--stargazers:CoolONEOfficial/ranepa_timetable--> - Customizable schedule viewer with native integrations by [Nikolai Trukhin](https://github.com/CoolONEOfficial)
 
 ## Utilities
 


### PR DESCRIPTION
Adding RANEPA Timetable app in open source apps section

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only

---

Feel free to add this badge to your repository after it's accepted to **awesome-flutter**.

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```
