### PR TITLE
Add attranslate to Internationalization

### DIFF
--- a/source.md
+++ b/source.md
@@ -298,6 +298,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 - [GenLang](https://github.com/KingWu/gen_lang) <!--stargazers:KingWu/gen_lang--> - Code generator for Internationalization by [King Wu](https://github.com/KingWu)
 - [Flutter Translate](https://github.com/bratan/flutter_translate) <!--stargazers:bratan/flutter_translate--> - Internationalization (i18n) library by [Florin Bratan](http://bratan.me)
+- [attranslate](https://github.com/fkirc/attranslate) - Semi-automated translation of ARB or JSON files by [fkirc](https://github.com/fkirc)
 
 ### Build automation
 


### PR DESCRIPTION
## Description

I felt that Flutter is still lacking some tool-support for translations, which is why I wrote `attranslate`: https://github.com/fkirc/attranslate
Note that this is not a replacement for tools like `flutter_translate`, but a complementary tool.
It runs only on the developer's machine or CI-workflows (without any impact on running apps).

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only

---

Feel free to add this badge to your repository after it's accepted to **awesome-flutter**.

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```
