### PR TITLE
Add gate - injection dependency generator

### DIFF
--- a/source.md
+++ b/source.md
@@ -484,6 +484,7 @@ Simon Binder](https://github.com/simolus3)
 - [Flux](https://github.com/google/flutter_flux) <!--stargazers:google/flutter_flux--> - Implementation of the Flux framework by Google
 - [Fish](https://github.com/alibaba/fish-redux) <!--stargazers:alibaba/fish-redux--> - Alibaba Redux implementation
 - [Async Redux](https://pub.dev/packages/async_redux) <!--stargazers:marcglasberg/async_redux--> - Redux without boilerplate. Allows for both sync and async reducers by [Marcelo Glasberg](https://github.com/marcglasberg/)
+- [Gate](https://github.com/Apparence-io/gate) <!--stargazers:Apparence-io/gate--> - Simple dependency injection using only annotations and build_runner [Apparence studio](https://github.com/Apparence-io)
 
 ### Widgets
 


### PR DESCRIPTION
## Description

As google inject is now deprecated since dart 2. We worked on a solution inspired from it. 
We made this with a vision of simplicity like on spring boot. This only requires annotations and run the flutter build runner.

[A complete documentation is available here in the generator sub package. ](https://github.com/Apparence-io/gate)

*Working on some video and tutorial.* 


**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
- [x] Added a link to the repo in the PR
