### PR TITLE
add go_router in Navigation category

### DIFF
--- a/source.md
+++ b/source.md
@@ -282,7 +282,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Deep Link Navigation](https://github.com/Dennis-Krasnov/Flutter-Deep-Link-Navigation) <!--stargazers:Dennis-Krasnov/Flutter-Deep-Link-Navigation--> - Elegant abstraction for complete deep linking navigation in Flutter by [Dennis Krasnov](https://denniskrasnov.com)
 - [Get](https://github.com/jonataslaw/get) <!--stargazers:jonataslaw/get--> - Navigate between screens & display snackbars/dialogs/bottomSheets without context by [Jonny Borges](https://github.com/jonataslaw)
 - [Beamer](https://github.com/slovnicki/beamer) <!--stargazers:slovnicki/beamer--> - Route through guarded page stacks and URLs using the Navigator 2.0 API effortlessly by [Sandro Lovnički](https://github.com/slovnicki)
-- [go_router](https://github.com/csells/go_router) <!--stargazers:csells/go_router--> - Use declarative routes to reduce complexity, handling deep linking from Android, iOS and and the web while still allowing an easy-to-use developer experience. [Chris Sells](https://github.com/csells).
+- [go_router](https://github.com/csells/go_router) <!--stargazers:csells/go_router--> - Declarative routes to reduce complexity, deep linking for mobile and the web while maintaining developer experience by [Chris Sells](https://github.com/csells).
 
 ### Auth
 

--- a/source.md
+++ b/source.md
@@ -282,7 +282,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Deep Link Navigation](https://github.com/Dennis-Krasnov/Flutter-Deep-Link-Navigation) <!--stargazers:Dennis-Krasnov/Flutter-Deep-Link-Navigation--> - Elegant abstraction for complete deep linking navigation in Flutter by [Dennis Krasnov](https://denniskrasnov.com)
 - [Get](https://github.com/jonataslaw/get) <!--stargazers:jonataslaw/get--> - Navigate between screens & display snackbars/dialogs/bottomSheets without context by [Jonny Borges](https://github.com/jonataslaw)
 - [Beamer](https://github.com/slovnicki/beamer) <!--stargazers:slovnicki/beamer--> - Route through guarded page stacks and URLs using the Navigator 2.0 API effortlessly by [Sandro Lovnički](https://github.com/slovnicki)
-- [go_router](https://github.com/csells/go_router) <!--stargazers:csells/go_router--> - Use declarative routes to reduce complexity, regardless of the platform you're targeting (mobile, web, desktop), handling deep linking from Android, iOS and the web while still allowing an easy-to-use developer experience. [Chris Sells](https://github.com/csells).
+- [go_router](https://github.com/csells/go_router) <!--stargazers:csells/go_router--> - Use declarative routes to reduce complexity, handling deep linking from Android, iOS and and the web while still allowing an easy-to-use developer experience. [Chris Sells](https://github.com/csells).
 
 ### Auth
 

--- a/source.md
+++ b/source.md
@@ -282,6 +282,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Deep Link Navigation](https://github.com/Dennis-Krasnov/Flutter-Deep-Link-Navigation) <!--stargazers:Dennis-Krasnov/Flutter-Deep-Link-Navigation--> - Elegant abstraction for complete deep linking navigation in Flutter by [Dennis Krasnov](https://denniskrasnov.com)
 - [Get](https://github.com/jonataslaw/get) <!--stargazers:jonataslaw/get--> - Navigate between screens & display snackbars/dialogs/bottomSheets without context by [Jonny Borges](https://github.com/jonataslaw)
 - [Beamer](https://github.com/slovnicki/beamer) <!--stargazers:slovnicki/beamer--> - Route through guarded page stacks and URLs using the Navigator 2.0 API effortlessly by [Sandro Lovnički](https://github.com/slovnicki)
+- [go_router](https://github.com/csells/go_router) <!--stargazers:csells/go_router--> - Use declarative routes to reduce complexity, regardless of the platform you're targeting (mobile, web, desktop), handling deep linking from Android, iOS and the web while still allowing an easy-to-use developer experience. [Chris Sells](https://github.com/csells).
 
 ### Auth
 


### PR DESCRIPTION
## Description

https://github.com/csells/go_router

go_router it's a great router package for Flutter navigation. I think that the awesome list should include it in the Navigation category.

The feature that shines the most is easy to write declarative routes. It has features like integration with Flutter Navigator 2.0, deep linking, error handling, redirection, route debugging, nested navigation, etc. All of these features are well documented on the documentation website https://gorouter.dev/

```dart
import 'package:flutter/material.dart';
import 'package:go_router/go_router.dart';

class App extends StatelessWidget {
  App({Key? key}) : super(key: key);

  final _router = GoRouter(
    routes: [
      GoRoute(
        path: '/',
        builder: (context, state) => const Page1Screen(),
      ),
      GoRoute(
        path: '/page2',
        builder: (context, state) => const Page2Screen(),
      ),
    ],
  );

  @override
  Widget build(BuildContext context) => MaterialApp.router(
        routeInformationParser: _router.routeInformationParser,
        routerDelegate: _router.routerDelegate,
      );
}
```

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
- [x] Added a link to the repo in the PR