### PR TITLE
Add `photo_manager`

### DIFF
--- a/source.md
+++ b/source.md
@@ -335,7 +335,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
  
 ### Media
 
-- [photo_manager](https://github.com/fluttercandies/flutter_photo_manager) <!--stargazers:fluttercandies/flutter_photo_manager--> - A Flutter plugin that providing assets (image/video/audio) abstraction management APIs easily without UI integration by [CaiJingLong](https://github.com/CaiJingLong) and [Alex Li](https://github.com/AlexV525).
+- [photo_manager](https://github.com/fluttercandies/flutter_photo_manager) <!--stargazers:fluttercandies/flutter_photo_manager--> - Provides assets (image/video/audio) abstraction management APIs that can be easily integrated with custom UI widgets by [CaiJingLong](https://github.com/CaiJingLong) and [Alex Li](https://github.com/AlexV525).
 
 #### Audio
 

--- a/source.md
+++ b/source.md
@@ -335,6 +335,8 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
  
 ### Media
 
+- [photo_manager](https://github.com/fluttercandies/flutter_photo_manager) <!--stargazers:fluttercandies/flutter_photo_manager--> - A Flutter plugin that provides assets abstraction management APIs without UI integration by [CaiJingLong](https://github.com/CaiJingLong) and [Alex Li](https://github.com/AlexV525).
+
 #### Audio
 
 - [Flutter Audio Recorder](https://github.com/shadow-app/flutter_audio_recorder) - Provides full controls and access to recording details such as level metering by [Wenyan Li](https://github.com/nikli2009).

--- a/source.md
+++ b/source.md
@@ -335,7 +335,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
  
 ### Media
 
-- [photo_manager](https://github.com/fluttercandies/flutter_photo_manager) <!--stargazers:fluttercandies/flutter_photo_manager--> - A Flutter plugin that provides assets abstraction management APIs without UI integration by [CaiJingLong](https://github.com/CaiJingLong) and [Alex Li](https://github.com/AlexV525).
+- [photo_manager](https://github.com/fluttercandies/flutter_photo_manager) <!--stargazers:fluttercandies/flutter_photo_manager--> - A Flutter plugin that providing assets (image/video/audio) abstraction management APIs easily without UI integration by [CaiJingLong](https://github.com/CaiJingLong) and [Alex Li](https://github.com/AlexV525).
 
 #### Audio
 


### PR DESCRIPTION
## Description

https://github.com/fluttercandies/flutter_photo_manager

Add the `photo_manager` plugin, it's the base plugin of `wechat_assets_picker` introduced in #793, and `advance_image_picker` introduced in #858, providing assets abstraction management APIs without UI integration.

I've also written a summary article about the plugin recently: [Hard to manage media with Flutter? Try photo_manager, the all-in-one solution](https://medium.flutter.cn/hard-to-manage-media-with-flutter-try-photo-manager-the-all-in-one-solution-5188599e4cf)

I didn't find a proper section that matches this plugin, but the **Media** is overall the best matched, please help me to update the section if necessary.

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
- [x] Added a link to the repo in the PR
