### PR TITLE
Update Battery package reference

### DIFF
--- a/source.md
+++ b/source.md
@@ -453,7 +453,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 - [WebView](https://github.com/dart-flitter/flutter_webview_plugin) <!--stargazers:dart-flitter/flutter_webview_plugin--> - Render web content by [Hadrien Lejard](https://twitter.com/HadrienLejard)
 - [Location](https://github.com/Lyokone/flutterlocation) <!--stargazers:Lyokone/flutterlocation--> - Handle location, handling callbacks to get continuous location by [Lyokone](https://github.com/Lyokone)
-- [Battery](https://pub.dev/packages/battery) - Access various information about the battery.
+- [Battery](https://pub.dev/packages/battery_plus) - Access various information about the battery.
 - [Proximity Sensor Plugin](https://pub.dev/packages/proximity_plugin) - A plugin to access the proximity sensor of your device by [Manoj NB](https://github.com/Samaritan1011001)
 - [Geolocation](https://github.com/loup-v/geolocation) <!--stargazers:loup-v/geolocation--> - Fully featured geolocation plugin: current location, location updates, geocode, places and more by [Loup](http://intheloup.io)
 - [Local Notifications](https://github.com/MaikuB/flutter_local_notifications) <!--stargazers:MaikuB/flutter_local_notifications--> - Plugin for displaying local notifications by [Michael Bui](https://github.com/MaikuB)


### PR DESCRIPTION
## Description

Since [battery](https://pub.dev/packages/battery) is discontinued, link has been replaced with [battery_plus](https://pub.dev/packages/battery_plus)

---

**Checklist**

- [X] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [X] I edited the SOURCE.md file only
- [X] Added a link to the repo in the PR
