### PR TITLE
Added quick type

### DIFF
--- a/source.md
+++ b/source.md
@@ -665,6 +665,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Awesome Snippets](https://marketplace.visualstudio.com/items?itemName=Nash.awesome-flutter-snippets) - Collection of commonly used classes and methods by [Nash](https://twitter.com/Nash0x7E2)
 - [Flutter Files](https://marketplace.visualstudio.com/items?itemName=gornivv.vscode-flutter-files) - Quick generation for BLoC templates files by context menu by [Gorniv](https://github.com/gorniv).
 - [Flutter Intl](https://marketplace.visualstudio.com/items?itemName=localizely.flutter-intl) - i18n binding from arb files by [Localizely](https://twitter.com/localizely)
+- [QuickType](https://marketplace.visualstudio.com/items?itemName=quicktype.quicktype) - Quick way to generate normal, freezed, and json_serializable JSON models by [Quicktype](https://github.com/quicktype/)
 
 
 ### IntelliJ / Android Studio


### PR DESCRIPTION
Please read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) before creating a submission.

## Description

Added Quicktype VSCode extension. Easy way to create JSON Models that is also compatible with
- freezed
- json_serializable
- normal JSON models (no library)

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
- [x] Added a link to the repo in the PR

---

Feel free to add this badge to your repository after it's accepted to **awesome-flutter**.

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```
