### PR TITLE
Replaced archived 'flutter_google_map_view' project with 'flutter_map'

### DIFF
--- a/source.md
+++ b/source.md
@@ -285,7 +285,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 ### Map
 
-- [Google Map View](https://github.com/apptreesoftware/flutter_google_map_view) <!--stargazers:apptreesoftware/flutter_google_map_view--> - Displaying google map plugin by [AppTree Software](https://www.linkedin.com/company/apptree-software/)
+- [flutter_map](https://github.com/fleaflet/flutter_map) <!--stargazers:fleaflet/flutter_map--> - A versatile yet simple mapping package for Flutter by [multiple maintainers](https://docs.fleaflet.dev/credits)
 - [GeoCoder](https://github.com/aloisdeniel/flutter_geocoder) <!--stargazers:aloisdeniel/flutter_geocoder--> - Forward and reverse geocoding by [Aloïs Deniel](https://aloisdeniel.github.com)
 - [Mapbox GL](https://github.com/mapbox/flutter-mapbox-gl) <!--stargazers:mapbox/flutter-mapbox-gl--> - Interactive, customizable vector maps by Mapbox
 - [AMap](https://github.com/fluttify-project/amap_map_fluttify) <!--stargazers:fluttify-project/amap_map_fluttify--> - Access to AMap services(高德地图) by [fluttify-project](https://github.com/fluttify-project)


### PR DESCRIPTION
'flutter_google_map_view' was archived and abandoned by the authors 'apptreesoftware'.
'flutter_map' was the replacement, now maintained by multiple maintainers (of which I am one), under the 'fleaflet' organisation.

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
- [x] Added a link to the repo in the PR
