### PR TITLE
Added smooth_page_indicator to UI section

### DIFF
--- a/source.md
+++ b/source.md
@@ -187,7 +187,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Rounded Loading Button](https://github.com/chrisedg87/flutter_rounded_loading_button) <!--stargazers:chrisedg87/flutter_rounded_loading_button--> - Button with a loading indicator, complete with success and error animations by [Chris Edgington](https://twitter.com/ChrisTheEdg)
 - [PlutoGrid](https://github.com/bosskmk/pluto_grid) <!--stargazers:bosskmk/pluto_grid--> - Web and desktop datagrid that can be controlled by the keyboard by [bosskmk](https://github.com/bosskmk).
 - [Flyer Chat](https://github.com/flyerhq/flutter_chat_ui) <!--stargazers:flyerhq/flutter_chat_ui--> - Community-driven chat UI implementation by the [Flyer Chat team](https://github.com/flyerhq)
-
+- [smooth_page_indicator](https://github.com/Milad-Akarie/smooth_page_indicator) <!--stargazers:Milad-Akarie/smooth_page_indicator--> - Customizable animated page indicator with a set of built-in effects. [Milad Akarie](https://github.com/Milad-Akarie)
 #### Sticky Headers
 
 - [Sticky Infinite List](https://github.com/TatsuUkraine/flutter_sticky_infinite_list) <!--stargazers:TatsuUkraine/flutter_sticky_infinite_list--> - Highly configurable multi directional infinite list with Sticky Headers by [TatsuUkraine](https://github.com/TatsuUkraine)


### PR DESCRIPTION
Please read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md) before creating a submission.

## Description
Added  [smooth_page_indicator](https://pub.dev/packages/smooth_page_indicator) to UI section, It's so far the number on page indicator on `pub.dev
`
---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
- [x] Added a link to the repo in the PR

---

Feel free to add this badge to your repository after it's accepted to **awesome-flutter**.

 <a href="https://stackoverflow.com/questions/tagged/flutter?sort=votes">
  <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
 </a>
 
 ``` 
<a href="https://github.com/Solido/awesome-flutter">
    <img alt="Awesome Flutter" src="https://img.shields.io/badge/Awesome-Flutter-blue.svg?longCache=true&style=flat-square" />
</a>
```
