### PR TITLE
Replace Zefyr with Fleather

### DIFF
--- a/source.md
+++ b/source.md
@@ -329,7 +329,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 
 - [Markdown](https://github.com/flutter/flutter_markdown) <!--stargazers:flutter/flutter_markdown--> - Markdown renderer for Flutter. It supports the original format, but no inline html
 - [Masked Text](https://github.com/benhurott/flutter-masked-text) <!--stargazers:benhurott/flutter-masked-text--> - Masked text with custom and monetary formatting by [Ben-hur Santos Ott](https://github.com/benhurott)
-- [Zefyr](https://github.com/memspace/zefyr) <!--stargazers:memspace/zefyr--> - Soft & gentle rich text editor by [Memspace](https://github.com/memspace/zefyr)
+- [Fleather](https://github.com/fleather-editor/fleather) <!--stargazersfleather-editor/fleather--> - Soft & gentle rich text editor
 - [AutoSizeText](https://github.com/leisim/auto_size_text) <!--stargazers:leisim/auto_size_text--> - Automatically resizes text to fit perfectly within its bounds by [Simon Leier](https://github.com/leisim).
 - [Parsed Text](https://github.com/fayeed/flutter_parsed_text) <!--stargazers:fayeed/flutter_parsed_text--> - Interactive text based on content recognition, also supports Regex by [Fayeed Pawaskar](https://github.com/fayeed/)
 - [TeX](https://github.com/shah-xad/flutter_tex) <!--stargazers:shah-xad/flutter_tex--> - Render Mathematics Equations with full HTML and JavaScript support by [Shahzad Akram](https://github.com/shah-xad)


### PR DESCRIPTION
## Description

This PR replaces [Zefyr](https://github.com/memspace/zefyr) with [Fleather](https://github.com/fleather-editor/fleather). Fleather is a fork of Zefyr maintained by some of Zefyr's contributors (@Amir-P, @amantoux, ...) and since Zefyr is not maintained for almost a year and no longer working with new versions of Flutter (3.0+), I think it no longer should be on the list.

---

**Checklist**

- [X] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [X] I edited the SOURCE.md file only
- [X] Added a link to the repo in the PR