### PR TITLE
Add flutter-skill: AI E2E testing bridge for Flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Simon Binder](https://github.com/simolus3)
 
 - [flutter_convenient_test](https://github.com/fzyzcjy/flutter_convenient_test) [556⭐] - Tests with action history, time travelling, screenshots, rapid re-execution, video recordings, interactive mode by [fzyzcjy](https://github.com/fzyzcjy).
 - [Patrol](https://github.com/leancodepl/patrol) [1131⭐] - Easy-to-learn, powerful UI testing framework eliminating limitations of `flutter_test`, `integration_test`, and `flutter_driver` by [LeanCode](https://leancode.co).
+- [flutter-skill](https://github.com/ai-dashboad/flutter-skill) - AI-powered E2E testing bridge for Claude, Cursor, and Windsurf. Gives AI eyes and hands inside Flutter apps across iOS, Android, Web, desktop, and 5 other platforms by [ai-dashboad](https://github.com/ai-dashboad).
 
 ### Web
 


### PR DESCRIPTION
Adding [flutter-skill](https://github.com/ai-dashboad/flutter-skill) to the Testing section.

**flutter-skill** gives AI eyes and hands inside any Flutter app — an E2E testing bridge for Claude, Cursor, and Windsurf. Supports Flutter across iOS, Android, Web, desktop, and 5 other platforms (Electron, Tauri, KMP, React Native, .NET MAUI).