### PR TITLE
Add FlutterProbe to Testing section

### DIFF
--- a/source.md
+++ b/source.md
@@ -577,6 +577,7 @@ Simon Binder](https://github.com/simolus3)
 ### Testing
 
 - [flutter_convenient_test](https://github.com/fzyzcjy/flutter_convenient_test) <!--stargazers:fzyzcjy/flutter_convenient_test--> - Tests with action history, time travelling, screenshots, rapid re-execution, video recordings, interactive mode by [fzyzcjy](https://github.com/fzyzcjy)
+- [FlutterProbe](https://github.com/AlphaWaveSystems/flutter-probe) <!--stargazers:AlphaWaveSystems/flutter-probe--> - High-performance E2E testing framework with natural language syntax and sub-50ms widget-tree access by [Alpha Wave Systems](https://github.com/AlphaWaveSystems)
 - [Patrol](https://github.com/leancodepl/patrol) <!--stargazers:leancodepl/patrol--> - Easy-to-learn, powerful UI testing framework eliminating limitations of `flutter_test`, `integration_test`, and `flutter_driver` by [LeanCode](https://leancode.co)
 
 ### Web


### PR DESCRIPTION
Adds [FlutterProbe](https://github.com/AlphaWaveSystems/flutter-probe) to the Testing section.

**What it is:** A high-performance E2E testing framework for Flutter mobile apps. Tests are written in ProbeScript (natural language DSL), executed with <50ms command round-trips via direct widget-tree access over WebSocket/JSON-RPC 2.0. Ships as a single Go binary with pre-built binaries for Linux, macOS, and Windows.

**Why it belongs here:**
- Flutter-specific — direct widget tree access, not an accessibility-layer wrapper
- Open source (BSL 1.1, converts to Apache 2.0)
- Active development — v0.2.0, regular commits
- Full [documentation site](https://alphawavesystems.github.io/flutter-probe/), README, and wiki
- CI/CD ready with pre-built binaries on GitHub Releases

Placed alphabetically between `flutter_convenient_test` and `Patrol`.