### PR TITLE
Add MiniWiki - privacy-first personal wiki app

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Taskist](https://github.com/huextrat/Taskist) [1051⭐] - Taskist is a ToDo List app for Task Management by [Hugo EXTRAT](https://github.com/huextrat).
 - [Tourism](https://github.com/bluemix/tourism-demo) [305⭐] - Tourism app based on redux w/ animations & i18n by [blueMix](https://github.com/bluemix/tourism-demo).
 - [Linwood Butterfly](https://github.com/LinwoodCloud/Butterfly) [1463⭐] - Powerful note taking app and an alternative to OneNote by [CodeDoctorDE](https://github.com/CodeDoctorDE).
+- [MiniWiki](https://github.com/wellsa-ai/miniwiki) [1⭐] - Privacy-first personal wiki, 100% offline, E2E encrypted (ChaCha20-Poly1305), wikilinks, FTS5 full-text search by [wellsa-ai](https://github.com/wellsa-ai).
 - [Trinity Orientation @ Univ Toronto](https://github.com/matthewtory/trinity-orientation-2018) [618⭐] - Orientation week at Trinity College, U of T by [Matthew Tory](https://github.com/matthewtory).
 - [Transform Widget](https://github.com/DrPaulT/flutter-engine-test) - Image widgets as 3D game engine sprites by [Paul Thomas](https://github.com/DrPaulT).
 - [Deer](https://github.com/aleksanderwozniak/deer) [459⭐] - Minimalist Todo Planner built using BLoC pattern by [Aleksander Woźniak](https://github.com/aleksanderwozniak).


### PR DESCRIPTION
## MiniWiki

A privacy-first personal wiki Flutter app that works 100% offline with E2E encryption.

**GitHub:** https://github.com/wellsa-ai/miniwiki

### Why it belongs here:
- Built with Flutter 3.41 + Material 3
- 100% offline — zero network calls
- E2E encrypted by default (ChaCha20-Poly1305 + HMAC-SHA256, 100K iterations)
- `[[Wikilinks]]` with auto-generated backlinks
- Full-text search (FTS5 with Korean tokenization)
- Cross-platform: iOS, Android, macOS
- 54 tests, 0 failures
- MIT licensed, open source

Fits naturally next to Linwood Butterfly in the note-taking apps section.