### PR TITLE
Add Tech Idara Flutter course in Urdu (Videos)

### DIFF
--- a/source.md
+++ b/source.md
@@ -160,6 +160,7 @@ If you appreciate the content 📖, support projects visibility, give 👍| ⭐|
 - [Flutter in Practice](https://www.youtube.com/playlist?list=PLhXZp00uXBk5TSY6YOdmpzp1yG3QbFvrN) - Free video courses for beginners & non-programmers by [Zaiste](https://zaiste.net/)
 - [Whatsupcoders](https://www.youtube.com/c/whatsupcoders) <!--youtube:list/PL6BTtm1PxwOUpt1muzFD3ErxWdCzLkYbI--> - Free video series on Flutter Widgets by [Kamal](https://github.com/whatsupcoders)
 - [Reso Coder](https://www.youtube.com/channel/UCSIvrn68cUk8CS8MbtBmBkA) - Intermediate and advanced videos by [Matej Rešetár](https://github.com/ResoCoder)
+- [Tech Idara](https://www.youtube.com/playlist?list=PLX97VxArfzkmXeUqUxeKW7XS8oYraH7A5) - [Urdu] 35-video course from Dart basics to advanced topics by [Ishaq Hassan](https://github.com/ishaquehassan)
 
 ## Components
 


### PR DESCRIPTION
Adds the Tech Idara Flutter course to the Videos section.

- **Resource:** [Tech Idara Flutter course (YouTube playlist)](https://www.youtube.com/playlist?list=PLX97VxArfzkmXeUqUxeKW7XS8oYraH7A5)
- **Language:** Urdu
- **Author:** [Ishaq Hassan](https://github.com/ishaquehassan)
- **Format:** 35 videos covering Dart basics through advanced Flutter (state management, APIs, custom painters, deployment).
- **Why it's awesome:** It's officially listed on [docs.flutter.dev/resources/courses](https://docs.flutter.dev/resources/courses) as the recommended Urdu-language Flutter resource. Fills a real gap for Urdu-speaking learners (~200M+ speakers globally).

Follows the contribution guidelines:
- Added to the bottom of the Videos category in `source.md` (not README).
- Format: `[resource](link) - Description by [Author](link to author)`.
- Capitalized start, no trailing whitespace, doesn't mention the word "Flutter" in description (implied).
- Individual PR, searched for existing duplicates first.