### PR TITLE
Add Dot Loader (flutter_dot_loader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Simon Binder](https://github.com/simolus3)
 - [Heroine](https://pub.dev/packages/heroine) [?⭐] - The queen of hero transitions by [whynotmake.it].
 - [Motor](https://pub.dev/packages/motor) [?⭐] - Unified motion system for Flutter - physics-based springs and duration-based curves by [whynotmake.it]
 - [SpinKit](https://github.com/jogboms/flutter_spinkit) [3114⭐] - Animated loading indicators by [Jeremiah Ogbomo](https://twitter.com/jogboms).
+- [Dot Loader](https://github.com/hooshyar/flutter_dot_loader) - Zero-dependency dot-matrix / LED loading animations with 60 patterns, scrolling marquee text and custom pixel frames by [Hooshyar](https://github.com/hooshyar).
 - [Villains](https://github.com/Norbert515/flutter_villains) [366⭐] - Page transition animations by [Norbert Kozsir](https://twitter.com/norbertkozsir).
 - [AnimatedTextKit](https://github.com/aagarwal1012/Animated-Text-Kit) [1735⭐] - A collection of cool text animations by [Ayush Agarwal](https://github.com/aagarwal1012/).
 - [Drawing Animation](https://github.com/biocarl/drawing_animation) [505⭐] - Create drawing line animations based on SVG path data by [Carl Hauck](https://twitter.com/cahaucks).


### PR DESCRIPTION
Adds [flutter_dot_loader](https://pub.dev/packages/flutter_dot_loader) to the Animation section, next to its closest peer (SpinKit).

- Zero-dependency dot-matrix / LED loading animations — 60 math-driven patterns, scrolling marquee text (built-in 5×7 pixel font), custom pixel-frame animations, and an AI-chat typing indicator (`DotLoader`).
- 160/160 pub points, v1.0.0 (stable, semver), MIT, verified publisher (dilacode.com), supports all six platforms + WASM.
- Live demo (gallery / playground / studio): https://hooshyar.github.io/flutter_dot_loader/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMBMGoK3z69AoD279iCzXv