### PR TITLE
Add FluxDown to "Open Source Apps/Top" Section

### DIFF
--- a/source.md
+++ b/source.md
@@ -670,6 +670,7 @@ This section contains libraries that take an experimental or unorthodox approach
 - [Let's Draw](https://github.com/JideGuru/flutter_drawing_board) <!--stargazers:JideGuru/flutter_drawing_board--> - A simple drawing app made by [JideGuru](https://github.com/JideGuru)
 - [Openreads](https://github.com/mateusz-bak/openreads-android) <!--stargazers:mateusz-bak/openreads-android--> - A simple privacy oriented mobile books tracker using Open Library API by [mateusz-bak](https://github.com/mateusz-bak)
 - [Table Habit](https://github.com/FriesI23/mhabit)  <!--stargazers:FriesI23/mhabit--> - A simple micro habit tracker made by [FriesI23](https://github.com/FriesI23)
+- [FluxDown](https://github.com/zerx-lab/FluxDown) <!--stargazers:zerx-lab/FluxDown--> - Multi-protocol download manager and free IDM alternative, powered by a Rust engine by [zerx-lab](https://github.com/zerx-lab)
 
 ## Utilities
 


### PR DESCRIPTION
## Description and links to repo and pubdev if any

**FluxDown** — https://github.com/zerx-lab/FluxDown (AGPL-3.0, ~1k stars)

A cross-platform, multi-protocol download manager and a free alternative to Internet Download Manager. The UI is written in Dart, the download engine in Rust + Tokio.

What it does:

- Dynamic, IDM-style segmentation — segments split at runtime and idle connections are re-tasked to rescue slow ones
- HTTP/HTTPS, FTP, BitTorrent (DHT / magnet), eD2K, HLS and DASH in one client
- Chrome / Edge / Firefox extensions with a three-layer download interception engine
- Resume across crashes and reboots, backed by SQLite with WAL
- Global token-bucket speed limiting, named queues, system tray
- Light/dark themes with 13 colour schemes and a responsive three-pane layout
- Runs on Windows, macOS, Linux, NAS (Docker) and Android

Screenshots and a live UI walkthrough are on the site: https://fluxdown.zerx.dev

![FluxDown](https://fluxdown.zerx.dev/og.png)

Entry added to the bottom of `Open Source Apps` / `Top` in `source.md`.

---

**Checklist**

- [x] I read [How to contribute](https://github.com/Solido/awesome-flutter/blob/master/contributing.md)
- [x] I edited the SOURCE.md file only
- [x] Added a link to the repo in the PR
